### PR TITLE
Fix setCustomName causing NPEs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.13.1+build.370-1.16
 
 # Mod Properties
-	mod_version = 1.2.5
+	mod_version = 1.2.6
 	maven_group = net.hyper_pigeon
 	archives_base_name = eldritch-mobs
 

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/EldritchMobsMod.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/EldritchMobsMod.java
@@ -25,6 +25,7 @@ public class EldritchMobsMod implements ModInitializer {
 			ComponentRegistry.INSTANCE.registerIfAbsent(new Identifier("eldritch_mobs:eldritch_modifiers"), ModifierInterface.class)
 			.attach(EntityComponentCallback.event(LivingEntity.class), ModifierComponent::new);
 
+	public static final EldritchMobsConfig CONFIG = AutoConfig.register(EldritchMobsConfig.class, JanksonConfigSerializer::new).getConfig();
 
 	public static void useAbility(ComponentProvider provider) {
 		ELDRITCH_MODIFIERS.get(provider).useAbility((MobEntity) provider);
@@ -62,15 +63,10 @@ public class EldritchMobsMod implements ModInitializer {
 		return ELDRITCH_MODIFIERS.get(provider).get_mod_string();
 	}
 
-
 	@Override
 	public void onInitialize() {
-		AutoConfig.register(EldritchMobsConfig.class, JanksonConfigSerializer::new);
 		CommandRegistrationCallback.EVENT.register(SummonEliteCommand::register);
 		CommandRegistrationCallback.EVENT.register(SummonUltraCommand::register);
 		CommandRegistrationCallback.EVENT.register(SummonEldritchCommand::register);
 	}
-
-
-
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
@@ -2,6 +2,7 @@ package net.hyper_pigeon.eldritch_mobs.mixin;
 
 import nerdhub.cardinal.components.api.component.ComponentProvider;
 import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
+import net.hyper_pigeon.eldritch_mobs.mod_components.interfaces.ModifierInterface;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
@@ -18,6 +19,7 @@ import net.minecraft.loot.LootTables;
 import net.minecraft.loot.context.LootContextTypes;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.tag.FluidTags;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.BlockPos;
@@ -26,6 +28,7 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -59,12 +62,35 @@ public abstract class LivingEntityMixin extends Entity implements ComponentProvi
 
     @Shadow public native void heal(float amount);
 
-    @Shadow protected abstract net.minecraft.loot.context.LootContext.Builder
-    getLootContextBuilder(boolean causedByPlayer, DamageSource source);
+    @Shadow protected abstract net.minecraft.loot.context.LootContext.Builder getLootContextBuilder(boolean causedByPlayer, DamageSource source);
 
+    @Unique
+    private boolean eldritchMobs_hasConfiguredName = false;
 
     public LivingEntityMixin(EntityType<?> type, World world) {
         super(type, world);
+    }
+
+    @Inject(
+            method = "tick",
+            at = @At("HEAD")
+    )
+    private void configureCustomName(CallbackInfo ci) {
+        // only attempt to apply a custom name to the mob on their first tick
+        if(!world.isClient && !eldritchMobs_hasConfiguredName) {
+            ModifierInterface modifiers = EldritchMobsMod.ELDRITCH_MODIFIERS.get(this);
+
+            // only apply custom name if the mob doesn't have one and their modifier provides one
+            boolean hasCustomName = this.getCustomName() != null && this.getCustomName().asString().equals("");
+            if (!modifiers.get_mod_string().equals("") && !hasCustomName) {
+                if (!EldritchMobsMod.CONFIG.turnOffNames) {
+                    this.setCustomName(new TranslatableText(modifiers.get_mod_string(), new Object[0]));
+                    this.setCustomNameVisible(true);
+                }
+            }
+
+            eldritchMobs_hasConfiguredName = true;
+        }
     }
 
     private boolean teleportTo(double x, double y, double z) {
@@ -232,5 +258,4 @@ public abstract class LivingEntityMixin extends Entity implements ComponentProvi
             lootTable.generateLoot(builder.build(LootContextTypes.ENTITY), this::dropStack);
         }
     }
-
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/MobEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/MobEntityMixin.java
@@ -13,7 +13,6 @@ import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Arm;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -45,19 +44,6 @@ public abstract class MobEntityMixin extends LivingEntity implements ComponentPr
     @Shadow protected int experiencePoints;
 
     EldritchMobsConfig config = AutoConfig.getConfigHolder(EldritchMobsConfig.class).getConfig();
-
-    @Inject(at = @At("RETURN"), method = "<init>(Lnet/minecraft/entity/EntityType;Lnet/minecraft/world/World;)V")
-    private void constructor(EntityType<? extends LivingEntity> entityType, World world, CallbackInfo ci){
-        if(!EldritchMobsMod.get_mod_list(this).equals("")){
-            //System.out.println(EldritchMobsMod.get_mod_list(this));
-            if(!(entityType == EntityType.WITHER) && !config.turnOffNames) {
-                this.setCustomName(new TranslatableText(EldritchMobsMod.get_mod_list(this), new Object[0]));
-            }
-            //this.setCustomNameVisible(true);
-        }
-
-    }
-
 
     @Inject(at = @At("HEAD"), method = "tick")
     public void ability_try(CallbackInfo callback) {

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/DeflectorComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/DeflectorComponent.java
@@ -83,6 +83,21 @@ public class DeflectorComponent implements ModifierInterface {
     }
 
     @Override
+    public void setIs_elite(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_ultra(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_eldritch(boolean bool) {
+
+    }
+
+    @Override
     public void fromTag(CompoundTag compoundTag) {
 
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/EnderComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/EnderComponent.java
@@ -53,6 +53,21 @@ public class EnderComponent implements ModifierInterface {
     }
 
     @Override
+    public void setIs_elite(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_ultra(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_eldritch(boolean bool) {
+
+    }
+
+    @Override
     public void fromTag(CompoundTag compoundTag) {
 
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/LifestealComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/LifestealComponent.java
@@ -57,6 +57,21 @@ public class LifestealComponent implements ModifierInterface {
     }
 
     @Override
+    public void setIs_elite(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_ultra(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_eldritch(boolean bool) {
+
+    }
+
+    @Override
     public void fromTag(CompoundTag compoundTag) {
 
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ModifierComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ModifierComponent.java
@@ -1,29 +1,26 @@
 package net.hyper_pigeon.eldritch_mobs.mod_components.modifiers;
 
-import javafx.print.PageLayout;
 import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
 import net.hyper_pigeon.eldritch_mobs.config.EldritchMobsConfig;
 import net.hyper_pigeon.eldritch_mobs.mod_components.interfaces.ModifierInterface;
-import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.RangedAttackMob;
 import net.minecraft.entity.boss.WitherEntity;
 import net.minecraft.entity.boss.dragon.EnderDragonEntity;
 import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.entity.data.DataTracker;
-import net.minecraft.entity.data.TrackedData;
-import net.minecraft.entity.data.TrackedDataHandlerRegistry;
-import net.minecraft.entity.effect.StatusEffectInstance;
-import net.minecraft.entity.effect.StatusEffects;
-import net.minecraft.entity.mob.*;
+import net.minecraft.entity.mob.AmbientEntity;
+import net.minecraft.entity.mob.CreeperEntity;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.mob.WaterCreatureEntity;
 import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundTag;
 import org.apache.commons.lang3.text.WordUtils;
-import org.lwjgl.system.CallbackI;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Random;
 
 public class ModifierComponent implements ModifierInterface {
 

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/RustComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/RustComponent.java
@@ -54,6 +54,21 @@ public class RustComponent implements ModifierInterface {
     }
 
     @Override
+    public void setIs_elite(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_ultra(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_eldritch(boolean bool) {
+
+    }
+
+    @Override
     public void fromTag(CompoundTag compoundTag) {
 
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ThornyComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ThornyComponent.java
@@ -53,6 +53,21 @@ public class ThornyComponent implements ModifierInterface {
     }
 
     @Override
+    public void setIs_elite(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_ultra(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_eldritch(boolean bool) {
+
+    }
+
+    @Override
     public void fromTag(CompoundTag compoundTag) {
 
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ToxicComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ToxicComponent.java
@@ -56,6 +56,21 @@ public class ToxicComponent implements ModifierInterface {
     }
 
     @Override
+    public void setIs_elite(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_ultra(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_eldritch(boolean bool) {
+
+    }
+
+    @Override
     public void fromTag(CompoundTag compoundTag) {
 
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/WitheringComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/WitheringComponent.java
@@ -53,6 +53,21 @@ public class WitheringComponent implements ModifierInterface {
     }
 
     @Override
+    public void setIs_elite(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_ultra(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_eldritch(boolean bool) {
+
+    }
+
+    @Override
     public void fromTag(CompoundTag compoundTag) {
 
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/YeeterComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/YeeterComponent.java
@@ -63,6 +63,21 @@ public class YeeterComponent implements ModifierInterface {
     }
 
     @Override
+    public void setIs_elite(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_ultra(boolean bool) {
+
+    }
+
+    @Override
+    public void setIs_eldritch(boolean bool) {
+
+    }
+
+    @Override
     public void fromTag(CompoundTag compoundTag) {
 
     }

--- a/src/main/resources/eldritch_mobs.mixins.json
+++ b/src/main/resources/eldritch_mobs.mixins.json
@@ -4,12 +4,11 @@
   "package": "net.hyper_pigeon.eldritch_mobs.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "CreeperEntityMixin",
     "LivingEntityMixin",
-    "MobEntityMixin",
-    "CreeperEntityMixin"
+    "MobEntityMixin"
   ],
   "client": [
-
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This fixes the NPE Eldritch Mobs has with mobs that have boss bars. I moved the constructor `setCustomName` call to only occur on the entity's first tick. This will not override nametags. Tested with vanilla bosses & AdventureZ Stone Golem in the modfest pack outside dev.

(Master branch doesn't compile, so I also included simple changes to get it running). Version bump to 1.2.6.