### PR TITLE
Update Cardinal Components to V3 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
+	id 'fabric-loom' version '0.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -13,12 +13,17 @@ group = project.maven_group
 
 repositories {
 	maven {
-		name = "Ladysnake Libs"
+		name = "Ladysnake Mods"
 		url = 'https://ladysnake.jfrog.io/artifactory/mods'
+		content {
+			includeGroup 'io.github.ladysnake'
+			includeGroupByRegex 'io\\.github\\.onyxstudios.*'
+		}
 	}
 	maven {
 		url "https://maven.terraformersmc.com/"
 	}
+	maven { url "https://maven.shedaniel.me/" }
 
 }
 
@@ -39,18 +44,8 @@ dependencies {
 	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:${project.cardinal_version}"
 	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-chunk:${project.cardinal_version}"
 
-	modApi "me.shedaniel.cloth:config-2:4.8.2", {
-		exclude group: "net.fabricmc.fabric-api"
-	}
-	include "me.shedaniel.cloth:config-2:4.8.2", {
-		exclude group: "net.fabricmc.fabric-api"
-	}
-
-	modApi "me.sargunvohra.mcmods:autoconfig1u:3.2.2", {
-		exclude group: "net.fabricmc.fabric-api"
-	}
-	include "me.sargunvohra.mcmods:autoconfig1u:3.2.2", {
-		exclude group: "net.fabricmc.fabric-api"
+	modApi("me.shedaniel.cloth:cloth-config-fabric:4.11.26") {
+		exclude(group: "net.fabricmc.fabric-api")
 	}
 
 	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/EldritchMobsMod.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/EldritchMobsMod.java
@@ -1,7 +1,7 @@
 package net.hyper_pigeon.eldritch_mobs;
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import me.sargunvohra.mcmods.autoconfig1u.serializer.JanksonConfigSerializer;
+import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import nerdhub.cardinal.components.api.ComponentRegistry;
 import nerdhub.cardinal.components.api.ComponentType;
 import nerdhub.cardinal.components.api.component.ComponentProvider;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/EldritchMobsMod.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/EldritchMobsMod.java
@@ -2,10 +2,9 @@ package net.hyper_pigeon.eldritch_mobs;
 
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
-import nerdhub.cardinal.components.api.ComponentRegistry;
-import nerdhub.cardinal.components.api.ComponentType;
-import nerdhub.cardinal.components.api.component.ComponentProvider;
-import nerdhub.cardinal.components.api.event.EntityComponentCallback;
+import dev.onyxstudios.cca.api.v3.component.ComponentRegistry;
+import dev.onyxstudios.cca.api.v3.component.ComponentKey;
+import dev.onyxstudios.cca.api.v3.component.ComponentProvider;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.tag.TagRegistry;
@@ -32,9 +31,8 @@ import net.minecraft.util.registry.Registry;
 
 public class EldritchMobsMod implements ModInitializer {
 
-	public static final ComponentType<ModifierInterface> ELDRITCH_MODIFIERS =
-			ComponentRegistry.INSTANCE.registerIfAbsent(new Identifier("eldritch_mobs:eldritch_modifiers"), ModifierInterface.class)
-			.attach(EntityComponentCallback.event(LivingEntity.class), ModifierComponent::new);
+	public static final ComponentKey<ModifierInterface> ELDRITCH_MODIFIERS =
+			ComponentRegistry.getOrCreate(new Identifier("eldritch_mobs:eldritch_modifiers"), ModifierInterface.class);
 
 
 	public static final EldritchMobsConfig CONFIG = AutoConfig.register(EldritchMobsConfig.class, JanksonConfigSerializer::new).getConfig();

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/commands/SummonEldritchCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/commands/SummonEldritchCommand.java
@@ -5,7 +5,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
 import net.hyper_pigeon.eldritch_mobs.config.EldritchMobsConfig;
 import net.minecraft.command.argument.EntitySummonArgumentType;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/commands/SummonEliteCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/commands/SummonEliteCommand.java
@@ -5,7 +5,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
 import net.hyper_pigeon.eldritch_mobs.config.EldritchMobsConfig;
 import net.minecraft.command.argument.EntitySummonArgumentType;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/commands/SummonUltraCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/commands/SummonUltraCommand.java
@@ -5,7 +5,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
 import net.hyper_pigeon.eldritch_mobs.config.EldritchMobsConfig;
 import net.minecraft.command.argument.EntitySummonArgumentType;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/config/EldritchMobsConfig.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/config/EldritchMobsConfig.java
@@ -3,7 +3,7 @@ package net.hyper_pigeon.eldritch_mobs.config;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
-import blue.endless.jankson.Comment;
+import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
 import net.hyper_pigeon.eldritch_mobs.mod_components.modifiers.ModifierComponent;
 
 @Config(name = "eldritch_mobs")

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/config/EldritchMobsConfig.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/config/EldritchMobsConfig.java
@@ -1,9 +1,9 @@
 package net.hyper_pigeon.eldritch_mobs.config;
 
-import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.ConfigEntry;
-import me.sargunvohra.mcmods.autoconfig1u.shadowed.blue.endless.jankson.Comment;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import blue.endless.jankson.Comment;
 import net.hyper_pigeon.eldritch_mobs.mod_components.modifiers.ModifierComponent;
 
 @Config(name = "eldritch_mobs")

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/config/ModMenuIntegration.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/config/ModMenuIntegration.java
@@ -2,7 +2,7 @@ package net.hyper_pigeon.eldritch_mobs.config;
 
 import io.github.prospector.modmenu.api.ConfigScreenFactory;
 import io.github.prospector.modmenu.api.ModMenuApi;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.Screen;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/CreeperEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/CreeperEntityMixin.java
@@ -1,6 +1,6 @@
 package net.hyper_pigeon.eldritch_mobs.mixin;
 
-import nerdhub.cardinal.components.api.component.ComponentProvider;
+import dev.onyxstudios.cca.api.v3.component.ComponentProvider;
 import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.effect.StatusEffects;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
@@ -1,6 +1,6 @@
 package net.hyper_pigeon.eldritch_mobs.mixin;
 
-import nerdhub.cardinal.components.api.component.ComponentProvider;
+import dev.onyxstudios.cca.api.v3.component.ComponentProvider;
 import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
 import net.hyper_pigeon.eldritch_mobs.item.SoothingLantern;
 import net.hyper_pigeon.eldritch_mobs.mod_components.interfaces.ModifierInterface;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/MobEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/MobEntityMixin.java
@@ -1,7 +1,7 @@
 package net.hyper_pigeon.eldritch_mobs.mixin;
 
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import nerdhub.cardinal.components.api.component.ComponentProvider;
 import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
 import net.hyper_pigeon.eldritch_mobs.config.EldritchMobsConfig;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/EldritchMobsComponents.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/EldritchMobsComponents.java
@@ -1,0 +1,14 @@
+package net.hyper_pigeon.eldritch_mobs.mod_components;
+
+import dev.onyxstudios.cca.api.v3.entity.EntityComponentFactoryRegistry;
+import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
+import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
+import net.hyper_pigeon.eldritch_mobs.mod_components.modifiers.ModifierComponent;
+import net.minecraft.entity.LivingEntity;
+
+public final class EldritchMobsComponents implements EntityComponentInitializer {
+    @Override
+    public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
+        registry.registerFor(LivingEntity.class, EldritchMobsMod.ELDRITCH_MODIFIERS, ModifierComponent::new);
+    }
+}

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/interfaces/ModifierInterface.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/interfaces/ModifierInterface.java
@@ -1,5 +1,6 @@
 package net.hyper_pigeon.eldritch_mobs.mod_components.interfaces;
 
+import dev.onyxstudios.cca.api.v3.component.Component;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.mob.MobEntity;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/interfaces/ModifierInterface.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/interfaces/ModifierInterface.java
@@ -1,6 +1,5 @@
 package net.hyper_pigeon.eldritch_mobs.mod_components.interfaces;
 
-import nerdhub.cardinal.components.api.component.Component;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.mob.MobEntity;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/AlchemyComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/AlchemyComponent.java
@@ -138,13 +138,13 @@ public class AlchemyComponent implements ModifierInterface {
 
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return compoundTag;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 
 

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/BeserkComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/BeserkComponent.java
@@ -83,12 +83,12 @@ public class BeserkComponent implements ModifierInterface {
 
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return compoundTag;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/BlindingComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/BlindingComponent.java
@@ -99,12 +99,12 @@ public class BlindingComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return compoundTag;
+    public void writeToNbt(CompoundTag compoundTag) {
+        ;
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/BurningComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/BurningComponent.java
@@ -96,12 +96,12 @@ public class BurningComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/CloakedComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/CloakedComponent.java
@@ -79,12 +79,12 @@ public class CloakedComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/DeflectorComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/DeflectorComponent.java
@@ -103,12 +103,12 @@ public class DeflectorComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/DrainingComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/DrainingComponent.java
@@ -98,12 +98,12 @@ public class DrainingComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/DrowningComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/DrowningComponent.java
@@ -95,12 +95,12 @@ public class DrowningComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/DuplicatorComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/DuplicatorComponent.java
@@ -91,12 +91,12 @@ public class DuplicatorComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/EnderComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/EnderComponent.java
@@ -73,12 +73,12 @@ public class EnderComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/GhastlyComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/GhastlyComponent.java
@@ -110,12 +110,12 @@ public class GhastlyComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/GravityComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/GravityComponent.java
@@ -120,12 +120,12 @@ public class GravityComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/LethargicComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/LethargicComponent.java
@@ -96,12 +96,12 @@ public class LethargicComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/LifestealComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/LifestealComponent.java
@@ -77,12 +77,12 @@ public class LifestealComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ModifierComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ModifierComponent.java
@@ -278,7 +278,7 @@ public class ModifierComponent implements ModifierInterface {
 
 
     @Override
-    public void fromTag(CompoundTag tag) {
+    public void readFromNbt(CompoundTag tag) {
         this.setIs_elite(tag.getBoolean("elite"));
         this.setIs_ultra(tag.getBoolean("ultra"));
         this.setIs_eldritch(tag.getBoolean("eldritch"));
@@ -295,7 +295,7 @@ public class ModifierComponent implements ModifierInterface {
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag tag) {
+    public void writeToNbt(CompoundTag tag) {
         tag.putBoolean("elite", this.is_elite);
         tag.putBoolean("ultra", this.is_ultra);
         tag.putBoolean("eldritch", this.is_eldritch);
@@ -308,8 +308,6 @@ public class ModifierComponent implements ModifierInterface {
 
         tag.put("saved_mods", saved_mods);
 
-
-        return tag;
     }
 
     public void spawnedInLampChunk(){

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ModifierComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ModifierComponent.java
@@ -1,6 +1,6 @@
 package net.hyper_pigeon.eldritch_mobs.mod_components.modifiers;
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
 import net.hyper_pigeon.eldritch_mobs.config.EldritchMobsConfig;
 import net.hyper_pigeon.eldritch_mobs.mod_components.interfaces.ModifierInterface;

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/One_UpComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/One_UpComponent.java
@@ -81,12 +81,12 @@ public class One_UpComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/RegeneratingComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/RegeneratingComponent.java
@@ -75,12 +75,12 @@ public class RegeneratingComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ResistantComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ResistantComponent.java
@@ -77,12 +77,12 @@ public class ResistantComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/RustComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/RustComponent.java
@@ -74,12 +74,12 @@ public class RustComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/SnatcherComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/SnatcherComponent.java
@@ -109,13 +109,13 @@ public class SnatcherComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 
 

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/SpeedsterComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/SpeedsterComponent.java
@@ -79,12 +79,12 @@ public class SpeedsterComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/SprintingComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/SprintingComponent.java
@@ -86,12 +86,12 @@ public class SprintingComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/StarvingComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/StarvingComponent.java
@@ -94,12 +94,12 @@ public class StarvingComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/StormyComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/StormyComponent.java
@@ -96,12 +96,12 @@ public class StormyComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ThornyComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ThornyComponent.java
@@ -73,12 +73,12 @@ public class ThornyComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ToxicComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/ToxicComponent.java
@@ -76,12 +76,12 @@ public class ToxicComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/WeaknessComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/WeaknessComponent.java
@@ -96,12 +96,12 @@ public class WeaknessComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/WebslingingComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/WebslingingComponent.java
@@ -91,12 +91,12 @@ public class WebslingingComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/WitheringComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/WitheringComponent.java
@@ -73,12 +73,12 @@ public class WitheringComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return null;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/YeeterComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mod_components/modifiers/YeeterComponent.java
@@ -92,12 +92,12 @@ public class YeeterComponent implements ModifierInterface {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
 
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
-        return compoundTag;
+    public void writeToNbt(CompoundTag compoundTag) {
+
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,9 @@
     "main": [
       "net.hyper_pigeon.eldritch_mobs.EldritchMobsMod"
     ],
+	"cardinal-components-entity": [
+      "net.hyper_pigeon.eldritch_mobs.mod_components.EldritchMobsComponents"
+	],
     "modmenu": [
       "net.hyper_pigeon.eldritch_mobs.config.ModMenuIntegration"
     ]
@@ -36,5 +39,10 @@
   },
   "suggests": {
     "flamingo": "*"
+  },
+  "custom": {
+	"cardinal-components": [
+	  "eldritch_mobs:eldritch_modifiers"
+	]
   }
 }


### PR DESCRIPTION
MC 1.17 is right around the corner, and that means no more V2 API for Cardinal Components. This PR updates Eldritch Mobs to use V3 classes and methods, which should simplify the eventual porting process.

I also updated Cloth Config in the process, replacing AutoConfig. **Note that this means users have to manually add Cloth Config for Eldritch Mobs to function.** You can choose to include it again like you did with autoconfig before, but it will increase the file size by a bit.