### PR TITLE
Remove "check" displayed in server console in LivingEntityMixin.class

### DIFF
--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
@@ -399,7 +399,6 @@ public abstract class LivingEntityMixin extends Entity implements ComponentProvi
     protected void dropEldritchLoot (DamageSource source, boolean causedByPlayer, CallbackInfo info) {
         if(!EldritchMobsMod.CONFIG.enableCustomLoot) {
             if (EldritchMobsMod.isElite(this) && causedByPlayer) {
-                System.out.println("check");
                 Identifier identifier = new Identifier("eldritch_mobs:entity/elite_loot");
                 LootTable lootTable = this.world.getServer().getLootManager().getTable(identifier);
                 net.minecraft.loot.context.LootContext.Builder builder = this.getLootContextBuilder(causedByPlayer, source);

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
@@ -94,7 +94,6 @@ public abstract class LivingEntityMixin extends Entity implements ComponentProvi
             // only apply custom name if the mob doesn't have one and their modifier provides one
             boolean hasCustomName = this.getCustomName() != null && this.getCustomName().asString().equals("");
             if (!modifiers.get_mod_string().equals("") && !hasCustomName) {
-                System.out.println("check");
                 this.setCustomNameVisible(false);
                 if (!EldritchMobsMod.CONFIG.turnOffNames) {
                     this.setCustomName(new TranslatableText(modifiers.get_mod_string(), new Object[0]));


### PR DESCRIPTION
I've been playing the Medieval Minecraft modpack and kept seeing "check" in server console. Decided to get the strings of every jar and grep for "check".

Found this here 😛