### PR TITLE
Updated to 1.21.2/1.21.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,22 +3,22 @@ org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-	minecraft_version=1.21
-	yarn_mappings=1.21+build.9
-	loader_version=0.15.11
+	minecraft_version=1.21.2
+	yarn_mappings=1.21.2+build.1
+	loader_version=0.18.4
 
 
 
 # Mod Properties
-	mod_version = 1.16.4
+	mod_version = 1.17.0
 	maven_group = net.hyper_pigeon
 	archives_base_name = eldritch-mobs
 
 # Dependencies
-	fabric_version=0.100.8+1.21
-	cardinal_version=6.1.1
-	modmenu_version=11.0.1
-	config_version=15.0.128
-	polymer_version=0.9.9+1.21
-	polymer_blocks_version=0.9.9+1.21
-	server_translation_api_version=2.3.1+1.21-pre2
+	fabric_version=0.106.1+1.21.2
+	cardinal_version=6.2.2
+	modmenu_version=12.0.0
+	config_version=16.0.143
+	polymer_version=0.10.0+1.21.2
+	polymer_blocks_version=0.10.0+1.21.2
+	server_translation_api_version=2.4.0+1.21.2-rc1

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/AlchemistAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/AlchemistAbility.java
@@ -64,7 +64,7 @@ public class AlchemistAbility implements Ability {
                 RegistryEntry<Potion> potion = target.hasInvertedHealingAndHarm()
                         ? (ALCHEMIST_CONFIG.useStrongHealing ? Potions.STRONG_HEALING : Potions.HEALING)
                         : (ALCHEMIST_CONFIG.useStrongHarming ? Potions.STRONG_HARMING : Potions.HARMING);
-                PotionEntity potionEntity = new PotionEntity(mobEntity.getEntityWorld(), mobEntity);
+                PotionEntity potionEntity = new PotionEntity(mobEntity.getEntityWorld(), mobEntity, PotionContentsComponent.createStack(Items.SPLASH_POTION, potion));
                 potionEntity.setItem(PotionContentsComponent.createStack(Items.SPLASH_POTION, potion));
                 potionEntity.setPitch(potionEntity.getPitch() - 20);
                 potionEntity.setVelocity(d, e + (double) (g * 0.2F), f, 0.25F, 8.0F);

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/DrowningAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/DrowningAbility.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.world.ServerWorld;
 
 public class DrowningAbility implements Ability {
 
@@ -35,7 +36,8 @@ public class DrowningAbility implements Ability {
         if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
             LivingEntity target = mobEntity.getTarget();
             if (!(target.hasStatusEffect(StatusEffects.WATER_BREATHING))) {
-                target.damage(mobEntity.getDamageSources().drown(), drowningConfig.drowningDamage);
+                //world can be cast because we query if it is !client
+                target.damage((ServerWorld) mobEntity.getEntityWorld(), mobEntity.getDamageSources().drown(), drowningConfig.drowningDamage);
             }
         }
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/AbilityBlacklistManager.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/AbilityBlacklistManager.java
@@ -1,10 +1,8 @@
 package net.hyper_pigeon.eldritch_mobs.ability.data;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.hyper_pigeon.eldritch_mobs.ability.AbilityHelper;
+import net.hyper_pigeon.eldritch_mobs.ability.data.records.AbilityBlacklistData;
 import net.minecraft.entity.EntityType;
 import net.minecraft.registry.Registries;
 import net.minecraft.resource.JsonDataLoader;
@@ -16,9 +14,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class AbilityBlacklistManager extends JsonDataLoader implements IdentifiableResourceReloadListener {
+public class AbilityBlacklistManager extends JsonDataLoader<AbilityBlacklistData> implements IdentifiableResourceReloadListener {
     public AbilityBlacklistManager() {
-        super(new Gson(), "ability_blacklist");
+        super(AbilityBlacklistData.CODEC, "ability_blacklist");
     }
 
     @Override
@@ -27,24 +25,16 @@ public class AbilityBlacklistManager extends JsonDataLoader implements Identifia
     }
 
     @Override
-    protected void apply(Map<Identifier, JsonElement> prepared, ResourceManager manager, Profiler profiler) {
-        prepared.forEach((id, element) -> {
-            JsonObject jsonObject = element.getAsJsonObject();
-            String name = jsonObject.get("name").getAsString();
+    protected void apply(Map<Identifier, AbilityBlacklistData> prepared , ResourceManager manager, Profiler profiler) {
+        prepared.forEach((id, data) -> {
 
             List<EntityType<?>> entityTypeList = new ArrayList<>();
-            for (var entry : element.getAsJsonObject().get("entities").getAsJsonArray()) {
-                String namespace = entry.getAsString();
-                if (namespace.contains("minecraft:")) {
-                    String[] split_namespace = namespace.split(":");
-                    entityTypeList.add(Registries.ENTITY_TYPE.get(Identifier.tryParse(split_namespace[1])));
-                } else {
-                    entityTypeList.add(Registries.ENTITY_TYPE.get(Identifier.tryParse(namespace)));
-                }
+
+            for (Identifier identifier : data.entities()) {
+                entityTypeList.add(Registries.ENTITY_TYPE.get(identifier));
             }
 
-            AbilityHelper.addBlacklist(name, entityTypeList);
-
+            AbilityHelper.addBlacklist(data.name(), entityTypeList);
         });
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/CustomAbilityManager.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/CustomAbilityManager.java
@@ -1,13 +1,11 @@
 package net.hyper_pigeon.eldritch_mobs.ability.data;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.hyper_pigeon.eldritch_mobs.ability.AbilityHelper;
 import net.hyper_pigeon.eldritch_mobs.ability.AbilitySubType;
 import net.hyper_pigeon.eldritch_mobs.ability.AbilityType;
 import net.hyper_pigeon.eldritch_mobs.ability.ActivationType;
+import net.hyper_pigeon.eldritch_mobs.ability.data.records.AbilityConfigurationData;
 import net.minecraft.resource.JsonDataLoader;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
@@ -15,10 +13,10 @@ import net.minecraft.util.profiler.Profiler;
 
 import java.util.Map;
 
-public class CustomAbilityManager extends JsonDataLoader implements IdentifiableResourceReloadListener {
+public class CustomAbilityManager extends JsonDataLoader<AbilityConfigurationData> implements IdentifiableResourceReloadListener {
 
     public CustomAbilityManager() {
-        super(new Gson(), "ability");
+        super(AbilityConfigurationData.CODEC, "ability");
     }
 
     @Override
@@ -27,28 +25,30 @@ public class CustomAbilityManager extends JsonDataLoader implements Identifiable
     }
 
     @Override
-    protected void apply(Map<Identifier, JsonElement> prepared, ResourceManager manager, Profiler profiler) {
-        prepared.forEach((id, element) -> {
-            JsonObject jsonObject = element.getAsJsonObject();
+    protected void apply(Map<Identifier, AbilityConfigurationData> prepared, ResourceManager manager, Profiler profiler) {
 
-            if(!AbilityHelper.includesAbility(jsonObject.get("name").getAsString())) {
-                ActivationType activationType = ActivationType.valueOf(jsonObject.get("activationType").getAsString());
+        prepared.forEach((id, data) -> {
+
+            if (!AbilityHelper.includesAbility(data.name())) {
+
+                ActivationType activationType =
+                        ActivationType.valueOf(data.activationType());
 
                 CustomAbility customAbility = new CustomAbility(
-                        jsonObject.get("name").getAsString(),
-                        AbilityType.valueOf(jsonObject.get("type").getAsString()),
-                        AbilitySubType.valueOf(jsonObject.get("subtype").getAsString()),
+                        data.name(),
+                        AbilityType.valueOf(data.type()),
+                        AbilitySubType.valueOf(data.subtype()),
                         activationType,
-                        jsonObject.get("command").getAsString()
+                        data.command()
                 );
 
                 if (activationType == ActivationType.hasTarget) {
-                    long cooldown = jsonObject.get("cooldown").getAsLong();
-                    customAbility.setCooldown(cooldown);
+                    customAbility.setCooldown(data.cooldown());
                 }
 
                 AbilityHelper.addAbility(customAbility);
             }
         });
     }
+
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/records/AbilityBlacklistData.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/records/AbilityBlacklistData.java
@@ -1,0 +1,19 @@
+package net.hyper_pigeon.eldritch_mobs.ability.data.records;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+
+public record AbilityBlacklistData(
+        String name,
+        List<Identifier> entities
+) {
+    public static final Codec<AbilityBlacklistData> CODEC =
+            RecordCodecBuilder.create(instance -> instance.group(
+                    Codec.STRING.fieldOf("name").forGetter(AbilityBlacklistData::name),
+                    Identifier.CODEC.listOf().fieldOf("entities").forGetter(AbilityBlacklistData::entities)
+            ).apply(instance, AbilityBlacklistData::new));
+}
+

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/records/AbilityConfigurationData.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/records/AbilityConfigurationData.java
@@ -1,0 +1,24 @@
+package net.hyper_pigeon.eldritch_mobs.ability.data.records;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+public record AbilityConfigurationData(
+        String name,
+        String activationType,
+        String type,
+        String subtype,
+        String command,
+        long cooldown
+
+) {
+    public static final Codec<AbilityConfigurationData> CODEC =
+            RecordCodecBuilder.create(instance -> instance.group(
+                    Codec.STRING.fieldOf("name").forGetter(AbilityConfigurationData::name),
+                    Codec.STRING.fieldOf("activationType").forGetter(AbilityConfigurationData::activationType),
+                    Codec.STRING.fieldOf("type").forGetter(AbilityConfigurationData::type),
+                    Codec.STRING.fieldOf("subtype").forGetter(AbilityConfigurationData::subtype),
+                    Codec.STRING.fieldOf("command").forGetter(AbilityConfigurationData::command),
+                    Codec.LONG.fieldOf("cooldown").forGetter(AbilityConfigurationData::cooldown)
+            ).apply(instance, AbilityConfigurationData::new));
+}

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/passive/defensive/ThornyAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/passive/defensive/ThornyAbility.java
@@ -7,6 +7,7 @@ import net.hyper_pigeon.eldritch_mobs.ability.AbilityType;
 import net.hyper_pigeon.eldritch_mobs.config.EldritchMobsConfig;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.server.world.ServerWorld;
 
 public class ThornyAbility implements Ability {
 
@@ -29,8 +30,8 @@ public class ThornyAbility implements Ability {
 
     @Override
     public void onDamaged(LivingEntity entity, DamageSource source, float amount) {
-        if (source.getAttacker() != null && source.getAttacker().isAlive()) {
-            source.getAttacker().damage(entity.getDamageSources().magic(), (float) (amount * thornyConfig.thornyReturnDamage));
+        if (source.getAttacker() != null && source.getAttacker().isAlive() && entity.getWorld() instanceof ServerWorld serverWorld) {
+            source.getAttacker().damage(serverWorld , entity.getDamageSources().magic(), (float) (amount * thornyConfig.thornyReturnDamage));
         }
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/block/SoothingLanternBlock.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/block/SoothingLanternBlock.java
@@ -21,6 +21,7 @@ import net.minecraft.world.ServerWorldAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 import org.jetbrains.annotations.Nullable;
+import xyz.nucleoid.packettweaker.PacketContext;
 
 public class SoothingLanternBlock extends Block implements PolymerHeadBlock {
 
@@ -50,7 +51,7 @@ public class SoothingLanternBlock extends Block implements PolymerHeadBlock {
 //    }
 
     @Override
-    public String getPolymerSkinValue(BlockState state, BlockPos pos, ServerPlayerEntity player) {
+    public String getPolymerSkinValue(BlockState state, BlockPos pos, PacketContext context) {
         return state.get(LIT) ? ACTIVE_SKIN : INACTIVE_SKIN;
     }
 

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEldritchCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEldritchCommand.java
@@ -81,7 +81,8 @@ public class SummonEldritchCommand {
             NbtCompound nbtCompound = nbt.copy();
             nbtCompound.putString("id", entityType.registryKey().getValue().toString());
             ServerWorld serverWorld = source.getWorld();
-            Entity entity = EntityType.loadEntityWithPassengers(nbtCompound, serverWorld, entityx -> {
+            SpawnReason spawnReason = SpawnReason.COMMAND;
+            Entity entity = EntityType.loadEntityWithPassengers(nbtCompound, serverWorld, spawnReason, entityx -> {
                 entityx.refreshPositionAndAngles(pos.x, pos.y, pos.z, entityx.getYaw(), entityx.getPitch());
                 return entityx;
             });

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEliteCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEliteCommand.java
@@ -72,7 +72,8 @@ public class SummonEliteCommand {
             NbtCompound nbtCompound = nbt.copy();
             nbtCompound.putString("id", entityType.registryKey().getValue().toString());
             ServerWorld serverWorld = source.getWorld();
-            Entity entity = EntityType.loadEntityWithPassengers(nbtCompound, serverWorld, entityx -> {
+            SpawnReason spawnReason = SpawnReason.COMMAND;
+            Entity entity = EntityType.loadEntityWithPassengers(nbtCompound, serverWorld, spawnReason, entityx -> {
                 entityx.refreshPositionAndAngles(pos.x, pos.y, pos.z, entityx.getYaw(), entityx.getPitch());
                 return entityx;
             });

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonUltraCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonUltraCommand.java
@@ -81,7 +81,8 @@ public class SummonUltraCommand {
             NbtCompound nbtCompound = nbt.copy();
             nbtCompound.putString("id", entityType.registryKey().getValue().toString());
             ServerWorld serverWorld = source.getWorld();
-            Entity entity = EntityType.loadEntityWithPassengers(nbtCompound, serverWorld, entityx -> {
+            SpawnReason spawnReason = SpawnReason.COMMAND;
+            Entity entity = EntityType.loadEntityWithPassengers(nbtCompound, serverWorld, spawnReason, entityx -> {
                 entityx.refreshPositionAndAngles(pos.x, pos.y, pos.z, entityx.getYaw(), entityx.getPitch());
                 return entityx;
             });

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/component/MobModifierComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/component/MobModifierComponent.java
@@ -150,10 +150,10 @@ public class MobModifierComponent implements ModifierComponent {
     }
 
     private void increaseMaxHealthForModifier(EntityAttributeModifier modifier) {
-        EntityAttributeInstance entityAttributeInstance = provider.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH);
+        EntityAttributeInstance entityAttributeInstance = provider.getAttributeInstance(EntityAttributes.MAX_HEALTH);
         assert entityAttributeInstance != null;
         if (!entityAttributeInstance.hasModifier(modifier.id())) entityAttributeInstance.addPersistentModifier(modifier);
-        provider.setHealth((float) provider.getAttributeValue(EntityAttributes.GENERIC_MAX_HEALTH));
+        provider.setHealth((float) provider.getAttributeValue(EntityAttributes.MAX_HEALTH));
     }
 
     public void increaseHealth() {

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
@@ -13,9 +13,9 @@ import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.loot.LootTable;
-import net.minecraft.loot.context.LootContextParameterSet;
 import net.minecraft.loot.context.LootContextParameters;
 import net.minecraft.loot.context.LootContextTypes;
+import net.minecraft.loot.context.LootWorldContext;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.entry.RegistryEntry;
@@ -28,6 +28,7 @@ import org.ladysnake.cca.api.v3.component.ComponentProvider;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -37,15 +38,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class LivingEntityMixin extends Entity implements ComponentProvider {
 
 
-    @Shadow public abstract boolean damage(DamageSource source, float amount);
+    @Unique
+    public abstract boolean damage(DamageSource source, float amount);
 
     @Shadow public abstract boolean addStatusEffect(StatusEffectInstance effect);
 
     @Shadow public abstract boolean hasStatusEffect(RegistryEntry<StatusEffect> effect);
-
-    @Shadow public abstract float getHealth();
-
-    @Shadow public abstract RegistryKey<LootTable> getLootTable();
 
     public LivingEntityMixin(EntityType<?> type, World world) {
         super(type, world);
@@ -70,8 +68,8 @@ public abstract class LivingEntityMixin extends Entity implements ComponentProvi
         }
     }
 
-    @Inject(method = "damage", at = @At("TAIL"))
-    private void applyOnDamageAbilities(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+    @Inject(method = "damage", at = @At("TAIL"), cancellable = true)
+    private void applyOnDamageAbilities(ServerWorld world, DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
         if (this.getType() != EntityType.PLAYER && notNormal(this)) {
             ActionResult result = onDamagedCallback.ON_DAMAGED.invoker().onDamaged((LivingEntity) (Object) (this), source, amount);
 
@@ -86,8 +84,8 @@ public abstract class LivingEntityMixin extends Entity implements ComponentProvi
         }
     }
 
-    @Inject(method = "damage", at = @At("TAIL"))
-    private void applyOnDamageToTarget(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+    @Inject(method = "damage", at = @At("TAIL"), cancellable = true)
+    private void applyOnDamageToTarget(ServerWorld world, DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
         Entity attacker = source.getAttacker();
         if (
                 attacker instanceof LivingEntity
@@ -132,7 +130,7 @@ public abstract class LivingEntityMixin extends Entity implements ComponentProvi
     }
 
     @Inject(at = @At("TAIL"), method = "dropLoot")
-    protected void dropBonusLoot(DamageSource source, boolean causedByPlayer, CallbackInfo info) {
+    protected void dropBonusLoot(ServerWorld world, DamageSource damageSource, boolean causedByPlayer, CallbackInfo ci) {
         if (this.getType() != EntityType.PLAYER && notNormal(this)
                 && (causedByPlayer || !EldritchMobsMod.ELDRITCH_MOBS_CONFIG.onlyDropLootIfKilledByPlayers)
                 && !EldritchMobsMod.ELDRITCH_MOBS_CONFIG.disableLootDrops) {
@@ -140,16 +138,16 @@ public abstract class LivingEntityMixin extends Entity implements ComponentProvi
             MinecraftServer server = this.getEntityWorld().getServer();
 
             if (server != null) {
-                net.minecraft.loot.context.LootContextParameterSet.Builder builder = new net.minecraft.loot.context.LootContextParameterSet.Builder(
+                LootWorldContext.Builder builder = new LootWorldContext.Builder(
                         (ServerWorld)this.getWorld()
                 )
                         .add(LootContextParameters.THIS_ENTITY, this)
                         .add(LootContextParameters.ORIGIN, this.getPos())
-                        .add(LootContextParameters.DAMAGE_SOURCE, source)
-                        .addOptional(LootContextParameters.ATTACKING_ENTITY, source.getAttacker())
-                        .addOptional(LootContextParameters.DIRECT_ATTACKING_ENTITY, source.getSource());
+                        .add(LootContextParameters.DAMAGE_SOURCE, damageSource)
+                        .addOptional(LootContextParameters.ATTACKING_ENTITY, damageSource.getAttacker())
+                        .addOptional(LootContextParameters.DIRECT_ATTACKING_ENTITY, damageSource.getSource());
 
-                LootContextParameterSet lootContextParameterSet = builder.build(LootContextTypes.ENTITY);
+                LootWorldContext lootContextParameterSet = builder.build(LootContextTypes.ENTITY);
 
                 LootTable eliteLootTable = this.getWorld().getServer().getReloadableRegistries().getLootTable(RegistryKey.of(RegistryKeys.LOOT_TABLE, EldritchMobsLootTables.ELITE_LOOT_ID));
                 LootTable ultraLootTable = this.getWorld().getServer().getReloadableRegistries().getLootTable(RegistryKey.of(RegistryKeys.LOOT_TABLE, EldritchMobsLootTables.ULTRA_LOOT_ID));
@@ -158,20 +156,20 @@ public abstract class LivingEntityMixin extends Entity implements ComponentProvi
                 switch (EldritchMobsMod.ELDRITCH_MODIFIERS.get(this).getRank()) {
                     case ELITE -> {
                         LootTable lootTable = this.getWorld().getServer().getReloadableRegistries().getLootTable(RegistryKey.of(RegistryKeys.LOOT_TABLE, EldritchMobsLootTables.ELITE_LOOT_ID));
-                        lootTable.generateLoot(lootContextParameterSet,this::dropStack);
+                        lootTable.generateLoot(lootContextParameterSet, stack -> this.dropStack((ServerWorld)this.getWorld(), stack));
                     }
                     case ULTRA -> {
                         LootTable lootTable = this.getWorld().getServer().getReloadableRegistries().getLootTable(RegistryKey.of(RegistryKeys.LOOT_TABLE, EldritchMobsLootTables.ULTRA_LOOT_ID));
-                        lootTable.generateLoot(lootContextParameterSet,this::dropStack);
+                        lootTable.generateLoot(lootContextParameterSet, stack -> this.dropStack((ServerWorld)this.getWorld(), stack));
                         if (EldritchMobsMod.ELDRITCH_MOBS_CONFIG.combinedLootDrop) {
-                            eliteLootTable.generateLoot(lootContextParameterSet,this::dropStack);
+                            eliteLootTable.generateLoot(lootContextParameterSet, stack -> this.dropStack((ServerWorld)this.getWorld(), stack));
                         }
                     }
                     case ELDRITCH -> {
-                        eldritchLootTable.generateLoot(lootContextParameterSet,this::dropStack);
+                        eldritchLootTable.generateLoot(lootContextParameterSet, stack -> this.dropStack((ServerWorld)this.getWorld(), stack));
                         if (EldritchMobsMod.ELDRITCH_MOBS_CONFIG.combinedLootDrop) {
-                            eliteLootTable.generateLoot(lootContextParameterSet,this::dropStack);
-                            ultraLootTable.generateLoot(lootContextParameterSet,this::dropStack);
+                            eliteLootTable.generateLoot(lootContextParameterSet, stack -> this.dropStack((ServerWorld)this.getWorld(), stack));
+                            ultraLootTable.generateLoot(lootContextParameterSet, stack -> this.dropStack((ServerWorld)this.getWorld(), stack));
                         }
                     }
                     default -> {}

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/GameRendererMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/GameRendererMixin.java
@@ -22,20 +22,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
 public class GameRendererMixin implements GameRendererExtensions {
-	@Unique
-	Entity targetedEldritch;
 
-	@Shadow
-	@Final
-	MinecraftClient client;
+	@Unique
+	private Entity targetedEldritch;
+
+	@Shadow @Final
+	private MinecraftClient client;
 
 	@Inject(
 			method = "renderWorld",
-			at = @At(
-					value = "INVOKE",
-					target = "Lnet/minecraft/client/MinecraftClient;getProfiler()Lnet/minecraft/util/profiler/Profiler;",
-					ordinal = 0
-			)
+			at = @At("HEAD")
 	)
 	private void injectUpdateOnGameRenderer(RenderTickCounter tickCounter, CallbackInfo ci) {
 		this.eldritch_mobs$updateTargetedEldritch(tickCounter.getTickDelta(true));
@@ -44,19 +40,30 @@ public class GameRendererMixin implements GameRendererExtensions {
 	@Override
 	public void eldritch_mobs$updateTargetedEldritch(float tickDelta) {
 		if (this.client.targetedEntity == null) {
-			var camera = this.client.getCameraEntity();
+			Entity camera = this.client.getCameraEntity();
 			this.targetedEldritch = null;
+
 			if (camera != null && this.client.world != null) {
 				var cameraVec = camera.getCameraPosVec(tickDelta);
 				var rotationVec = camera.getRotationVec(1.0F);
 				var reachVec = cameraVec.add(rotationVec.multiply(64.0));
-				var box = camera.getBoundingBox().stretch(rotationVec.multiply(64.0)).expand(1.0);
+				var box = camera.getBoundingBox()
+						.stretch(rotationVec.multiply(64.0))
+						.expand(1.0);
 
-				var hitResult = ProjectileUtil.raycast(camera, cameraVec, reachVec, box, entity -> !entity.isSpectator()
-                        && entity.canHit()
-						&& entity instanceof MobEntity
-                        && EldritchMobsMod.getRank((ComponentProvider) entity) != MobRank.NONE
-                        && EldritchMobsMod.getRank((ComponentProvider) entity) != MobRank.UNDECIDED, 4096.0);
+				var hitResult = ProjectileUtil.raycast(
+						camera,
+						cameraVec,
+						reachVec,
+						box,
+						entity -> !entity.isSpectator()
+								&& entity.canHit()
+								&& entity instanceof MobEntity
+								&& EldritchMobsMod.getRank((ComponentProvider) entity) != MobRank.NONE
+								&& EldritchMobsMod.getRank((ComponentProvider) entity) != MobRank.UNDECIDED,
+						4096.0
+				);
+
 				if (hitResult != null) {
 					this.targetedEldritch = hitResult.getEntity();
 				}
@@ -69,3 +76,4 @@ public class GameRendererMixin implements GameRendererExtensions {
 		return this.targetedEldritch;
 	}
 }
+

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/MobEntityRendererMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/MobEntityRendererMixin.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(MobEntityRenderer.class)
 public class MobEntityRendererMixin {
     @WrapOperation(
-            method = "hasLabel(Lnet/minecraft/entity/mob/MobEntity;)Z",
+            method = "hasLabel(Lnet/minecraft/entity/mob/MobEntity;D)Z",
             at = @At(
                     value = "FIELD",
                     target = "Lnet/minecraft/client/render/entity/EntityRenderDispatcher;targetedEntity:Lnet/minecraft/entity/Entity;"

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/WorldRendererMixin.java
@@ -4,6 +4,7 @@ import net.hyper_pigeon.eldritch_mobs.extensions.EntityRenderDispatcherExtension
 import net.hyper_pigeon.eldritch_mobs.extensions.GameRendererExtensions;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.util.ObjectAllocator;
 import net.minecraft.client.util.math.MatrixStack;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Final;
@@ -26,7 +27,7 @@ public class WorldRendererMixin {
                     target = "Lnet/minecraft/client/render/entity/EntityRenderDispatcher;configure(Lnet/minecraft/world/World;Lnet/minecraft/client/render/Camera;Lnet/minecraft/entity/Entity;)V"
             )
     )
-    private void configureDispatcher(RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, Matrix4f matrix4f2, CallbackInfo ci) {
+    private void configureDispatcher(ObjectAllocator allocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f positionMatrix, Matrix4f projectionMatrix, CallbackInfo ci) {
         ((EntityRenderDispatcherExtensions) this.entityRenderDispatcher).eldritch_mobs$configureTargetedEldritch(((GameRendererExtensions) gameRenderer).eldritch_mobs$getTargetedEldritch());
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/register/EldritchMobsBlocks.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/register/EldritchMobsBlocks.java
@@ -4,6 +4,7 @@ package net.hyper_pigeon.eldritch_mobs.register;
 import eu.pb4.polymer.core.api.block.PolymerHeadBlock;
 import eu.pb4.polymer.core.api.item.PolymerHeadBlockItem;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.hyper_pigeon.eldritch_mobs.EldritchMobsMod;
 import net.hyper_pigeon.eldritch_mobs.block.SoothingLanternBlock;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
@@ -12,6 +13,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroups;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.state.property.Properties;
 import net.minecraft.util.Identifier;
@@ -27,7 +30,7 @@ public class EldritchMobsBlocks {
     }
 
     public static final SoothingLanternBlock SOOTHING_LANTERN = new SoothingLanternBlock(
-            AbstractBlock.Settings.create()
+            AbstractBlock.Settings.create().registryKey(RegistryKey.of(RegistryKeys.BLOCK, Identifier.of(EldritchMobsMod.MOD_ID, "soothing_lantern")))
                     .requiresTool()
                     .strength(1.5F)
                     .sounds(BlockSoundGroup.METAL)
@@ -40,7 +43,9 @@ public class EldritchMobsBlocks {
 
 
     public static void init() {
-        registerHeadBlock("soothing_lantern", SOOTHING_LANTERN, new Item.Settings().maxCount(1));
+        registerHeadBlock("soothing_lantern", SOOTHING_LANTERN, new Item.Settings()
+                .registryKey(RegistryKey.of(RegistryKeys.ITEM, Identifier.of(EldritchMobsMod.MOD_ID, "soothing_lantern")))
+                .maxCount(1));
         ItemGroupEvents.modifyEntriesEvent(ItemGroups.REDSTONE).register((itemGroup) -> itemGroup.add(SOOTHING_LANTERN));
     }
 

--- a/src/main/resources/data/eldritch_mobs/lang/en_us.json
+++ b/src/main/resources/data/eldritch_mobs/lang/en_us.json
@@ -1,5 +1,6 @@
 {
   "block.eldritch_mobs.soothing_lantern": "Soothing Lantern",
+  "item.eldritch_mobs.soothing_lantern": "Soothing Lantern",
   "text.autoconfig.eldritch_mobs.title": "Eldritch Mobs Config",
   "text.autoconfig.eldritch_mobs.option.EliteSpawnRates": "Elite Spawn Rate",
   "text.autoconfig.eldritch_mobs.option.UltraSpawnRates": "Ultra Spawn Rate",

--- a/src/main/resources/data/eldritch_mobs/lang/ru_ru.json
+++ b/src/main/resources/data/eldritch_mobs/lang/ru_ru.json
@@ -1,5 +1,6 @@
 {
   "block.eldritch_mobs.soothing_lantern": "Успокаивающий фонарь",
+  "item.eldritch_mobs.soothing_lantern": "Успокаивающий фонарь",
   "text.autoconfig.eldritch_mobs.title": "Настройки сверхъестественных мобов",
   "text.autoconfig.eldritch_mobs.option.EliteSpawnRates": "Частота появления элит",
   "text.autoconfig.eldritch_mobs.option.UltraSpawnRates": "Частота появления ультр",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
   "depends": {
     "fabricloader": ">=0.15.0",
     "fabric": "*",
-    "minecraft": "~1.21",
+    "minecraft": ">=1.21.2",
     "java": ">=17",
     "cloth-config": ">=11.0.0"
   },


### PR DESCRIPTION
## Update to 1.21.2 & 1.21.3

### Bumped up version numbers
- bumped up to recommended versions of Fabric Loader, Yarn, and Fabric API for 1.21.2 (as listed on https://fabricmc.net/develop/)
- updated version numbers of the dependencies

### Update effort due to 1.21.2/1.21.3
- some methods now want a ServerWorld
-  EntityType.loadEntityWithPassengers() now wants a SpawnReason as input
- EntityAttributes.GENERIC_MAX_HEALTH was renamed to just MAX_HEALTH
- net.minecraft.loot.context.LootContextParameterSet was renamed to LootWorldContext
- manually set registry keys in the settings of every block and item because that is now neccessary

### Repaired Mixins that were broken by 1.21.2
- fixed method signatures
- changed the injection-point of GameRendererMixin because it no longer existed

### Refactored AbilityBlacklistManager & CustomAbilityManager
- was neccessary because the super-class JsonDataLoader got changed
- added neccassary records for that

## Testing
I tested the new version with minecraft versions 1.21.2 & 1.21.3 and it seemed to work fine, but I did not test it in great detail.
So maybe it would be best to test especially the changes that were made at AbilityBlacklistManager & CustomAbilityManager.

I used those versions of the dependecies in 1.21.2 to test:

- cardinal-components-api-6.2.2,jar
- cloth-config-16.0.143-fabric.jar
- fabric-api-0.106.1+1.21.2.jar

For 1.21.3 I used those:

- cardinal-components-api-6.2.2,jar
- cloth-config-16.0.143-fabric.jar
- fabric-api-0.114.1+1.21.3.jar