### PR TITLE
Update to 1.21.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,22 +3,22 @@ org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-	minecraft_version=1.21.2
-	yarn_mappings=1.21.2+build.1
+	minecraft_version=1.21.4
+	yarn_mappings=1.21.4+build.8
 	loader_version=0.18.4
 
 
 
 # Mod Properties
-	mod_version = 1.17.0
+	mod_version = 1.18.0
 	maven_group = net.hyper_pigeon
 	archives_base_name = eldritch-mobs
 
 # Dependencies
-	fabric_version=0.106.1+1.21.2
+	fabric_version=0.119.4+1.21.4
 	cardinal_version=6.2.2
-	modmenu_version=12.0.0
-	config_version=16.0.143
-	polymer_version=0.10.0+1.21.2
-	polymer_blocks_version=0.10.0+1.21.2
+	modmenu_version=13.0.3
+	config_version=17.0.144
+	polymer_version=0.11.8+1.21.4
+	polymer_blocks_version=0.11.8+1.21.4
 	server_translation_api_version=2.4.0+1.21.2-rc1

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/AbilityBlacklistManager.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/AbilityBlacklistManager.java
@@ -6,6 +6,7 @@ import net.hyper_pigeon.eldritch_mobs.ability.data.records.AbilityBlacklistData;
 import net.minecraft.entity.EntityType;
 import net.minecraft.registry.Registries;
 import net.minecraft.resource.JsonDataLoader;
+import net.minecraft.resource.ResourceFinder;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.profiler.Profiler;
@@ -16,7 +17,7 @@ import java.util.Map;
 
 public class AbilityBlacklistManager extends JsonDataLoader<AbilityBlacklistData> implements IdentifiableResourceReloadListener {
     public AbilityBlacklistManager() {
-        super(AbilityBlacklistData.CODEC, "ability_blacklist");
+        super(AbilityBlacklistData.CODEC, ResourceFinder.json("ability_blacklist"));
     }
 
     @Override

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/CustomAbilityManager.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/CustomAbilityManager.java
@@ -7,6 +7,7 @@ import net.hyper_pigeon.eldritch_mobs.ability.AbilityType;
 import net.hyper_pigeon.eldritch_mobs.ability.ActivationType;
 import net.hyper_pigeon.eldritch_mobs.ability.data.records.AbilityConfigurationData;
 import net.minecraft.resource.JsonDataLoader;
+import net.minecraft.resource.ResourceFinder;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.profiler.Profiler;
@@ -16,7 +17,7 @@ import java.util.Map;
 public class CustomAbilityManager extends JsonDataLoader<AbilityConfigurationData> implements IdentifiableResourceReloadListener {
 
     public CustomAbilityManager() {
-        super(AbilityConfigurationData.CODEC, "ability");
+        super(AbilityConfigurationData.CODEC, ResourceFinder.json("ability"));
     }
 
     @Override

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/MobEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/MobEntityMixin.java
@@ -44,7 +44,7 @@ public abstract class MobEntityMixin extends LivingEntity implements ComponentPr
         }
     }
 
-    @Inject(at = @At("HEAD"), method = "getXpToDrop")
+    @Inject(at = @At("HEAD"), method = "getExperienceToDrop")
     protected void multiplyXpDrop(CallbackInfoReturnable<Integer> cir) {
         if (EldritchMobsMod.ELDRITCH_MODIFIERS.get(this).getRank() != MobRank.NONE && EldritchMobsMod.ELDRITCH_MODIFIERS.get(this).getRank() != MobRank.UNDECIDED) {
             switch (EldritchMobsMod.ELDRITCH_MODIFIERS.get(this).getRank()) {

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/WorldRendererMixin.java
@@ -5,7 +5,6 @@ import net.hyper_pigeon.eldritch_mobs.extensions.GameRendererExtensions;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.entity.EntityRenderDispatcher;
 import net.minecraft.client.util.ObjectAllocator;
-import net.minecraft.client.util.math.MatrixStack;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -27,7 +26,7 @@ public class WorldRendererMixin {
                     target = "Lnet/minecraft/client/render/entity/EntityRenderDispatcher;configure(Lnet/minecraft/world/World;Lnet/minecraft/client/render/Camera;Lnet/minecraft/entity/Entity;)V"
             )
     )
-    private void configureDispatcher(ObjectAllocator allocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f positionMatrix, Matrix4f projectionMatrix, CallbackInfo ci) {
+    private void configureDispatcher(ObjectAllocator allocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, Matrix4f positionMatrix, Matrix4f projectionMatrix, CallbackInfo ci) {
         ((EntityRenderDispatcherExtensions) this.entityRenderDispatcher).eldritch_mobs$configureTargetedEldritch(((GameRendererExtensions) gameRenderer).eldritch_mobs$getTargetedEldritch());
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
   "depends": {
     "fabricloader": ">=0.15.0",
     "fabric": "*",
-    "minecraft": ">=1.21.2",
+    "minecraft": ">=1.21.4",
     "java": ">=17",
     "cloth-config": ">=11.0.0"
   },


### PR DESCRIPTION
## Update to 1.21.4

### Bumped up version numbers
- bumped up to recommended versions of Fabric Loader, Yarn, and Fabric API for 1.21.4 (as listed on https://fabricmc.net/develop/)
- updated version numbers of the dependencies

### Repaired Mixins that were broken by 1.21.4
- fixed method signature of the WorldRenderMixin
- changed the name of the target method "getXpDrop" in MobEntityMixin to "getExperienceToDrop" because it was renamed

### Update effort due to 1.21.4
- Updated the constructor of AbilityBlacklistManager & CustomAbilityManager because the constructor of the super class (JsonDataLoader) now expects a ResourceFinder instead of a String


## Testing
I tested the new version in minecraft 1.21.4 with:
- cardinal components api 6.2.2
- cloth config 17.0.144
- fabric api 0.119.4-1.21.4
