### PR TITLE
Repaired recipe for soothing lantern 1.21.4

### DIFF
--- a/src/main/resources/data/eldritch_mobs/recipe/soothing_lantern.json
+++ b/src/main/resources/data/eldritch_mobs/recipe/soothing_lantern.json
@@ -1,20 +1,14 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "EGE",
-    "GSG",
-    "EGE"
+    "#g#",
+    "gSg",
+    "#g#"
   ],
   "key": {
-    "E": {
-      "item": "minecraft:emerald"
-    },
-    "G": {
-      "item": "minecraft:gold_ingot"
-    },
-    "S": {
-      "item": "minecraft:sea_lantern"
-    }
+    "#": "minecraft:emerald",
+    "g": "minecraft:gold_ingot",
+    "S": "minecraft:sea_lantern"
   },
   "result": {
     "id": "eldritch_mobs:soothing_lantern",


### PR DESCRIPTION
While updating to 1.21.5 I noticed, that I broke the crafting recipe by updating past 1.21.1.
Somehow Mojang thought it is a good idea to change the format of crafting recipes each 1.21.X version

I already tested the recipe :)

Note: 
I used https://crafting.thedestruc7i0n.ca to generate the recipes and 1.21.2/1.21.3 is listed as a different option than 1.21.4 so I thought something may be different, even if I don't see a difference between 1.21.2/1.21.3 and 1.21.4.
Never the less I created a different PR for 1.21.4 