### PR TITLE
Updated to 1.21.6-1.21.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,22 +3,22 @@ org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-	minecraft_version=1.21.5
-	yarn_mappings=1.21.5+build.1
+	minecraft_version=1.21.8
+	yarn_mappings=1.21.8+build.1
 	loader_version=0.18.4
 
 
 
 # Mod Properties
-	mod_version = 1.19.0
+	mod_version = 1.20.0
 	maven_group = net.hyper_pigeon
 	archives_base_name = eldritch-mobs
 
 # Dependencies
-	fabric_version=0.128.2+1.21.5
-	cardinal_version=6.3.1
-	modmenu_version=14.0.1
-	config_version=18.0.145
-	polymer_version=0.12.6+1.21.5
-	polymer_blocks_version=0.12.6+1.21.5
+	fabric_version=0.136.1+1.21.8
+	cardinal_version=7.0.0-beta.1
+	modmenu_version=15.0.1
+	config_version=19.0.147
+	polymer_version=0.13.13+1.21.8
+	polymer_blocks_version=0.13.13+1.21.8
 	server_translation_api_version=2.5.1+1.21.5

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/defensive/SprinterAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/defensive/SprinterAbility.java
@@ -42,9 +42,9 @@ public class SprinterAbility implements Ability {
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && canUseAbility(mobEntity)) {
+        if (!mobEntity.getWorld().isClient() && canUseAbility(mobEntity)) {
             mobEntity.addStatusEffect(new StatusEffectInstance(StatusEffects.SPEED, sprinterConfig.duration, sprinterConfig.amplifier));
-            nextUseTime = mobEntity.getEntityWorld().getTime() + getCooldown();
+            nextUseTime = mobEntity.getWorld().getTime() + getCooldown();
         }
     }
 

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/AlchemistAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/AlchemistAbility.java
@@ -45,12 +45,12 @@ public class AlchemistAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && canUseAbility(mobEntity)) {
+        if (!mobEntity.getWorld().isClient() && canUseAbility(mobEntity)) {
             LivingEntity target = mobEntity.getTarget();
 
             if (target != null) {
@@ -64,12 +64,12 @@ public class AlchemistAbility implements Ability {
                 RegistryEntry<Potion> potion = target.hasInvertedHealingAndHarm()
                         ? (ALCHEMIST_CONFIG.useStrongHealing ? Potions.STRONG_HEALING : Potions.HEALING)
                         : (ALCHEMIST_CONFIG.useStrongHarming ? Potions.STRONG_HARMING : Potions.HARMING);
-                SplashPotionEntity potionEntity = new SplashPotionEntity(mobEntity.getEntityWorld(), mobEntity, PotionContentsComponent.createStack(Items.SPLASH_POTION, potion));
+                SplashPotionEntity potionEntity = new SplashPotionEntity(mobEntity.getWorld(), mobEntity, PotionContentsComponent.createStack(Items.SPLASH_POTION, potion));
                 potionEntity.setItem(PotionContentsComponent.createStack(Items.SPLASH_POTION, potion));
                 potionEntity.setPitch(potionEntity.getPitch() - 20);
                 potionEntity.setVelocity(d, e + (double) (g * 0.2F), f, 0.25F, 8.0F);
-                mobEntity.getEntityWorld().spawnEntity(potionEntity);
-                nextUseTime = getCooldown() + mobEntity.getEntityWorld().getTime();
+                mobEntity.getWorld().spawnEntity(potionEntity);
+                nextUseTime = getCooldown() + mobEntity.getWorld().getTime();
             }
         }
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/BlindingAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/BlindingAbility.java
@@ -38,12 +38,12 @@ public class BlindingAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
-            long time = mobEntity.getEntityWorld().getTime();
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
+            long time = mobEntity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
                 LivingEntity target = mobEntity.getTarget();

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/BurningAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/BurningAbility.java
@@ -36,13 +36,13 @@ public class BurningAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.getTarget().isAlive()) {
-            long time = mobEntity.getEntityWorld().getTime();
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.getTarget().isAlive()) {
+            long time = mobEntity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
                 LivingEntity target = mobEntity.getTarget();

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/DrainingAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/DrainingAbility.java
@@ -38,12 +38,12 @@ public class DrainingAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
-            long time = mobEntity.getEntityWorld().getTime();
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
+            long time = mobEntity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
                 LivingEntity target = mobEntity.getTarget();

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/DrowningAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/DrowningAbility.java
@@ -33,11 +33,11 @@ public class DrowningAbility implements Ability {
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
             LivingEntity target = mobEntity.getTarget();
             if (!(target.hasStatusEffect(StatusEffects.WATER_BREATHING))) {
                 //world can be cast because we query if it is !client
-                target.damage((ServerWorld) mobEntity.getEntityWorld(), mobEntity.getDamageSources().drown(), drowningConfig.drowningDamage);
+                target.damage((ServerWorld) mobEntity.getWorld(), mobEntity.getDamageSources().drown(), drowningConfig.drowningDamage);
             }
         }
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/DuplicatorAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/DuplicatorAbility.java
@@ -32,15 +32,15 @@ public class DuplicatorAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     public void onAbilityUse(MobEntity entity) {
-        if (!entity.getEntityWorld().isClient() && entity.getTarget() != null && entity.canSee(entity.getTarget()) && entity.getTarget().isAlive()) {
-            long time = entity.getEntityWorld().getTime();
+        if (!entity.getWorld().isClient() && entity.getTarget() != null && entity.canSee(entity.getTarget()) && entity.getTarget().isAlive()) {
+            long time = entity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
-                entity.getType().spawn((ServerWorld) entity.getEntityWorld(), entity.getBlockPos(), SpawnReason.REINFORCEMENT);
+                entity.getType().spawn((ServerWorld) entity.getWorld(), entity.getBlockPos(), SpawnReason.REINFORCEMENT);
             }
         }
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/GhastlyAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/GhastlyAbility.java
@@ -39,13 +39,13 @@ public class GhastlyAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
-            long time = mobEntity.getEntityWorld().getTime();
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
+            long time = mobEntity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
                 LivingEntity target = mobEntity.getTarget();
@@ -55,14 +55,14 @@ public class GhastlyAbility implements Ability {
                 double g = target.getBodyY(0.5D) - (0.5D + mobEntity.getBodyY(0.5D));
                 double h = target.getZ() - (mobEntity.getZ() + vec3d.z * 4.0D);
                 if (!mobEntity.isSilent()) {
-                    mobEntity.getEntityWorld().syncWorldEvent(null, 1016, mobEntity.getBlockPos(), 0);
+                    mobEntity.getWorld().syncWorldEvent(null, 1016, mobEntity.getBlockPos(), 0);
                 }
 
                 FireballEntity fireballEntity;
-                fireballEntity = new FireballEntity(mobEntity.getEntityWorld(), mobEntity, new Vec3d(f, g, h), ghastlyConfig.fireballPower);
+                fireballEntity = new FireballEntity(mobEntity.getWorld(), mobEntity, new Vec3d(f, g, h), ghastlyConfig.fireballPower);
 
                 fireballEntity.updatePosition(mobEntity.getX() + vec3d.x * 4.0D, mobEntity.getBodyY(0.5D) + 0.5D, fireballEntity.getZ() + vec3d.z * 4.0D);
-                mobEntity.getEntityWorld().spawnEntity(fireballEntity);
+                mobEntity.getWorld().spawnEntity(fireballEntity);
             }
         }
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/GravityAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/GravityAbility.java
@@ -40,13 +40,13 @@ public class GravityAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
-            long time = mobEntity.getEntityWorld().getTime();
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
+            long time = mobEntity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
 

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/LethargicAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/LethargicAbility.java
@@ -38,13 +38,13 @@ public class LethargicAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.getTarget().isAlive() && mobEntity.canSee(mobEntity.getTarget())) {
-            long time = mobEntity.getEntityWorld().getTime();
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.getTarget().isAlive() && mobEntity.canSee(mobEntity.getTarget())) {
+            long time = mobEntity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
                 LivingEntity target = mobEntity.getTarget();

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/StarvingAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/StarvingAbility.java
@@ -38,13 +38,13 @@ public class StarvingAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.getTarget().isAlive() && mobEntity.canSee(mobEntity.getTarget())) {
-            long time = mobEntity.getEntityWorld().getTime();
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.getTarget().isAlive() && mobEntity.canSee(mobEntity.getTarget())) {
+            long time = mobEntity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
                 LivingEntity target = mobEntity.getTarget();

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/StormyAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/StormyAbility.java
@@ -40,21 +40,21 @@ public class StormyAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
-            long time = mobEntity.getEntityWorld().getTime();
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
+            long time = mobEntity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
                 LivingEntity target = mobEntity.getTarget();
-                LightningEntity lightningEntity = new LightningEntity(EntityType.LIGHTNING_BOLT, mobEntity.getEntityWorld());
+                LightningEntity lightningEntity = new LightningEntity(EntityType.LIGHTNING_BOLT, mobEntity.getWorld());
 
                 Random random = new Random();
                 lightningEntity.setPos(target.getX() + random.nextInt(3), target.getY() + random.nextInt(3), target.getZ() + random.nextInt(3));
-                mobEntity.getEntityWorld().spawnEntity(lightningEntity);
+                mobEntity.getWorld().spawnEntity(lightningEntity);
             }
         }
     }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/WeaknessAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/WeaknessAbility.java
@@ -38,13 +38,13 @@ public class WeaknessAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.getTarget().isAlive() && mobEntity.canSee(mobEntity.getTarget())) {
-            long time = mobEntity.getEntityWorld().getTime();
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.getTarget().isAlive() && mobEntity.canSee(mobEntity.getTarget())) {
+            long time = mobEntity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
                 LivingEntity target = mobEntity.getTarget();

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/WebslingingAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/active/offensive/WebslingingAbility.java
@@ -38,13 +38,13 @@ public class WebslingingAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     @Override
     public void onAbilityUse(MobEntity mobEntity) {
-        if (!mobEntity.getEntityWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
-            long time = mobEntity.getEntityWorld().getTime();
+        if (!mobEntity.getWorld().isClient() && mobEntity.getTarget() != null && mobEntity.canSee(mobEntity.getTarget()) && mobEntity.getTarget().isAlive()) {
+            long time = mobEntity.getWorld().getTime();
             if (time > nextUseTime) {
                 nextUseTime = time + cooldown;
                 LivingEntity target = mobEntity.getTarget();
@@ -55,10 +55,10 @@ public class WebslingingAbility implements Ability {
 
                 BlockPos blockPos = new BlockPos(x,y,z);
 
-                if (target.getEntityWorld().getBlockState(blockPos).getBlock().equals(Blocks.AIR) ||
-                        target.getEntityWorld().getBlockState(blockPos).getBlock().equals(Blocks.CAVE_AIR)
-                        || target.getEntityWorld().getBlockState(blockPos).getBlock().equals(Blocks.VOID_AIR)) {
-                    target.getEntityWorld().setBlockState(blockPos, Blocks.COBWEB.getDefaultState());
+                if (target.getWorld().getBlockState(blockPos).getBlock().equals(Blocks.AIR) ||
+                        target.getWorld().getBlockState(blockPos).getBlock().equals(Blocks.CAVE_AIR)
+                        || target.getWorld().getBlockState(blockPos).getBlock().equals(Blocks.VOID_AIR)) {
+                    target.getWorld().setBlockState(blockPos, Blocks.COBWEB.getDefaultState());
                 }
 
             }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/CustomAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/data/CustomAbility.java
@@ -51,7 +51,7 @@ public class CustomAbility implements Ability {
 
     @Override
     public boolean canUseAbility(MobEntity mobEntity) {
-        return mobEntity.getEntityWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
+        return mobEntity.getWorld().getTime() > nextUseTime && mobEntity.getTarget() != null;
     }
 
     public long getCooldown() {
@@ -70,7 +70,7 @@ public class CustomAbility implements Ability {
             ServerCommandSource commandSource = mobEntity.getServer().getCommandSource();
             ParseResults<ServerCommandSource> parseResults = mobEntity.getServer().getCommandManager().getDispatcher().parse(parsedCommand, commandSource);
             mobEntity.getServer().getCommandManager().execute(parseResults, parsedCommand);
-            nextUseTime = mobEntity.getEntityWorld().getTime() + getCooldown();
+            nextUseTime = mobEntity.getWorld().getTime() + getCooldown();
         }
     }
 

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/passive/defensive/EnderAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/passive/defensive/EnderAbility.java
@@ -49,7 +49,7 @@ public class EnderAbility implements Ability {
     }
 
     private void teleportRandomly(LivingEntity livingEntity) {
-        if (!livingEntity.getEntityWorld().isClient() && livingEntity.isAlive()) {
+        if (!livingEntity.getWorld().isClient() && livingEntity.isAlive()) {
             double d = livingEntity.getX() + (livingEntity.getRandom().nextDouble() - 0.5D) * 25.0D;
             double e = livingEntity.getY() + (double) (livingEntity.getRandom().nextInt(64) - 32);
             double f = livingEntity.getZ() + (livingEntity.getRandom().nextDouble() - 0.5D) * 25.0D;
@@ -60,17 +60,17 @@ public class EnderAbility implements Ability {
     private void teleportTo(double x, double y, double z, LivingEntity livingEntity) {
         BlockPos.Mutable mutable = new BlockPos.Mutable(x, y, z);
 
-        while (mutable.getY() > 0 && !livingEntity.getEntityWorld().getBlockState(mutable).blocksMovement()) {
+        while (mutable.getY() > 0 && !livingEntity.getWorld().getBlockState(mutable).blocksMovement()) {
             mutable.move(Direction.DOWN);
         }
 
-        BlockState blockState = livingEntity.getEntityWorld().getBlockState(mutable);
+        BlockState blockState = livingEntity.getWorld().getBlockState(mutable);
         boolean bl = blockState.blocksMovement();
         boolean bl2 = blockState.getFluidState().isIn(FluidTags.WATER);
         if (bl && !bl2) {
             boolean bl3 = livingEntity.teleport(x, y, z, false);
             if (bl3 && !livingEntity.isSilent()) {
-                livingEntity.getEntityWorld().playSound(null, livingEntity.lastX, livingEntity.lastY, livingEntity.lastZ, SoundEvents.ENTITY_ENDERMAN_TELEPORT, livingEntity.getSoundCategory(), 1.0F, 1.0F);
+                livingEntity.getWorld().playSound(null, livingEntity.lastX, livingEntity.lastY, livingEntity.lastZ, SoundEvents.ENTITY_ENDERMAN_TELEPORT, livingEntity.getSoundCategory(), 1.0F, 1.0F);
                 livingEntity.playSound(SoundEvents.ENTITY_ENDERMAN_TELEPORT, 1.0F, 1.0F);
             }
         }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/passive/defensive/UndyingAbility.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/ability/passive/defensive/UndyingAbility.java
@@ -42,7 +42,7 @@ public class UndyingAbility implements Ability {
             entity.addStatusEffect(new StatusEffectInstance(StatusEffects.REGENERATION, undyingConfig.regenerationDuration, undyingConfig.regenerationAmplifier));
             entity.addStatusEffect(new StatusEffectInstance(StatusEffects.ABSORPTION, undyingConfig.absorptionDuration, undyingConfig.absorptionAmplifier));
             entity.addStatusEffect(new StatusEffectInstance(StatusEffects.FIRE_RESISTANCE, undyingConfig.fireResistanceDuration, 0));
-            entity.getEntityWorld().sendEntityStatus(entity, (byte) 35);
+            entity.getWorld().sendEntityStatus(entity, (byte) 35);
 
             abilityUsed = true;
         }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEldritchCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEldritchCommand.java
@@ -44,7 +44,7 @@ public class SummonEldritchCommand {
                                 ((RequiredArgumentBuilder)CommandManager.argument(
                                                 "entity", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)
                                         )
-                                        .suggests(SuggestionProviders.SUMMONABLE_ENTITIES)
+                                        .suggests(SuggestionProviders.cast(SuggestionProviders.SUMMONABLE_ENTITIES))
                                         .executes(
                                                 context -> execute((ServerCommandSource)context.getSource(), RegistryEntryReferenceArgumentType.getSummonableEntityType(context, "entity"), ((ServerCommandSource)context.getSource()).getPosition(), new NbtCompound(), true)
                                         ))
@@ -52,7 +52,7 @@ public class SummonEldritchCommand {
                                                 ((RequiredArgumentBuilder)CommandManager.argument(
                                                                 "entity", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)
                                                         )
-                                                        .suggests(SuggestionProviders.SUMMONABLE_ENTITIES)
+                                                        .suggests(SuggestionProviders.cast(SuggestionProviders.SUMMONABLE_ENTITIES))
                                                         .executes(
                                                                 context -> execute((ServerCommandSource)context.getSource(), RegistryEntryReferenceArgumentType.getSummonableEntityType(context, "entity"), ((ServerCommandSource)context.getSource()).getPosition(), new NbtCompound(), true)
                                                         ))

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEliteCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEliteCommand.java
@@ -44,7 +44,7 @@ public class SummonEliteCommand {
                                 ((RequiredArgumentBuilder)CommandManager.argument(
                                                 "entity", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)
                                         )
-                                        .suggests(SuggestionProviders.SUMMONABLE_ENTITIES)
+                                        .suggests(SuggestionProviders.cast(SuggestionProviders.SUMMONABLE_ENTITIES))
                                         .executes(
                                                 context -> execute((ServerCommandSource)context.getSource(), RegistryEntryReferenceArgumentType.getSummonableEntityType(context, "entity"), ((ServerCommandSource)context.getSource()).getPosition(), new NbtCompound(), true)
                                         ))

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonUltraCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonUltraCommand.java
@@ -44,7 +44,7 @@ public class SummonUltraCommand {
                                 ((RequiredArgumentBuilder)CommandManager.argument(
                                                 "entity", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)
                                         )
-                                        .suggests(SuggestionProviders.SUMMONABLE_ENTITIES)
+                                        .suggests(SuggestionProviders.cast(SuggestionProviders.SUMMONABLE_ENTITIES))
                                         .executes(
                                                 context -> execute((ServerCommandSource)context.getSource(), RegistryEntryReferenceArgumentType.getSummonableEntityType(context, "entity"), ((ServerCommandSource)context.getSource()).getPosition(), new NbtCompound(), true)
                                         ))
@@ -52,7 +52,7 @@ public class SummonUltraCommand {
                                                 ((RequiredArgumentBuilder)CommandManager.argument(
                                                                 "entity", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)
                                                         )
-                                                        .suggests(SuggestionProviders.SUMMONABLE_ENTITIES)
+                                                        .suggests(SuggestionProviders.cast(SuggestionProviders.SUMMONABLE_ENTITIES))
                                                         .executes(
                                                                 context -> execute((ServerCommandSource)context.getSource(), RegistryEntryReferenceArgumentType.getSummonableEntityType(context, "entity"), ((ServerCommandSource)context.getSource()).getPosition(), new NbtCompound(), true)
                                                         ))

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/component/MobModifierComponent.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/component/MobModifierComponent.java
@@ -19,6 +19,9 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.storage.NbtReadView;
+import net.minecraft.storage.ReadView;
+import net.minecraft.storage.WriteView;
 import net.minecraft.text.Text;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.hit.HitResult;
@@ -172,12 +175,12 @@ public class MobModifierComponent implements ModifierComponent {
     public ServerBossBar getBossBar() { return bossBar; }
 
     @Override
-    public void readFromNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
+    public void readData(ReadView view) {
 
-        healthIncreased = tag.getBoolean("healthIncreased", false);
-        numMaxAbilities = tag.getInt("numMaxAbilities", 0);
-        checkedIfSpawnedInSoothingLanternChunk = tag.getBoolean("checkedIfSpawnedInSoothingLanternChunk", false);
-        titleSet = tag.getBoolean("titleSet", false);
+        healthIncreased = view.getBoolean("healthIncreased", false);
+        numMaxAbilities = view.getInt("numMaxAbilities", 0);
+        checkedIfSpawnedInSoothingLanternChunk = view.getBoolean("checkedIfSpawnedInSoothingLanternChunk", false);
+        titleSet = view.getBoolean("titleSet", false);
 
         switch (numMaxAbilities) {
             case 1, 2, 3, 4 -> {
@@ -197,15 +200,17 @@ public class MobModifierComponent implements ModifierComponent {
 
         if (modifiers != null) modifiers.clear();
 
-        for (String name : tag.getCompoundOrEmpty("abilities").getKeys()) AbilityHelper.getAbilityRecordByName(name).ifPresent(record -> modifiers.add(record.ability));
+        if(view.read("abilities", NbtCompound.CODEC).isPresent()) {
+            for (String name : view.read("abilities", NbtCompound.CODEC).get().getKeys()) AbilityHelper.getAbilityRecordByName(name).ifPresent(record -> modifiers.add(record.ability));
+        }
     }
 
     @Override
-    public void writeToNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
-        tag.putBoolean("healthIncreased", healthIncreased);
-        tag.putInt("numMaxAbilities", numMaxAbilities);
-        tag.putBoolean("checkedIfSpawnedInSoothingLanternChunk", checkedIfSpawnedInSoothingLanternChunk);
-        tag.putBoolean("titleSet", titleSet);
+    public void writeData(WriteView view) {
+        view.putBoolean("healthIncreased", healthIncreased);
+        view.putInt("numMaxAbilities", numMaxAbilities);
+        view.putBoolean("checkedIfSpawnedInSoothingLanternChunk", checkedIfSpawnedInSoothingLanternChunk);
+        view.putBoolean("titleSet", titleSet);
 
         NbtCompound mobAbilities = new NbtCompound();
 
@@ -213,7 +218,7 @@ public class MobModifierComponent implements ModifierComponent {
             for (Ability ability : modifiers) mobAbilities.putString(ability.getName(), ability.getName());
         }
 
-        tag.put("abilities", mobAbilities);
+        view.put("abilities", NbtCompound.CODEC, mobAbilities);
     }
 
     public void makeMobNormal() {
@@ -228,7 +233,7 @@ public class MobModifierComponent implements ModifierComponent {
         Vec3d vec3d2 = player.getRotationVec(1.0F);
         Vec3d vec3d3 = vec3d.add(vec3d2.x * 100.0D, vec3d2.y * 100.0D, vec3d2.z * 100.0D);
         EntityHitResult entityHitResult = ProjectileUtil.getEntityCollision(
-                player.getEntityWorld(),
+                player.getWorld(),
                 player,
                 vec3d,
                 vec3d3,
@@ -247,8 +252,8 @@ public class MobModifierComponent implements ModifierComponent {
     @Override
     public void serverTick() {
         if (!checkedIfSpawnedInSoothingLanternChunk) {
-            if (this.rank != MobRank.NONE  && !provider.getEntityWorld().isClient) {
-                if(SoothingLanternPersistentState.get((ServerWorld) provider.getEntityWorld()).containsChunk(provider.getChunkPos())) {
+            if (this.rank != MobRank.NONE  && !provider.getWorld().isClient) {
+                if(SoothingLanternPersistentState.get((ServerWorld) provider.getWorld()).containsChunk(provider.getChunkPos())) {
                     makeMobNormal();
                 }
                 else {

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/LivingEntityMixin.java
@@ -135,7 +135,7 @@ public abstract class LivingEntityMixin extends Entity implements ComponentProvi
                 && (causedByPlayer || !EldritchMobsMod.ELDRITCH_MOBS_CONFIG.onlyDropLootIfKilledByPlayers)
                 && !EldritchMobsMod.ELDRITCH_MOBS_CONFIG.disableLootDrops) {
 
-            MinecraftServer server = this.getEntityWorld().getServer();
+            MinecraftServer server = this.getWorld().getServer();
 
             if (server != null) {
                 LootWorldContext.Builder builder = new LootWorldContext.Builder(

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/ServerPlayerEntityMixin.java
@@ -10,7 +10,6 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.hit.HitResult;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -24,10 +23,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ServerPlayerEntity.class)
 public abstract class ServerPlayerEntityMixin extends PlayerEntity {
 
-    @Shadow public abstract ServerWorld getServerWorld();
+    @Shadow public abstract ServerWorld getWorld();
 
-    public ServerPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile gameProfile) {
-        super(world, pos, yaw, gameProfile);
+    public ServerPlayerEntityMixin(World world, GameProfile gameProfile) {
+        super(world, gameProfile);
     }
 
 
@@ -39,7 +38,7 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity {
             Vec3d rotationVec = getRotationVec(1.0F);
             Vec3d reachVec = cameraVec.add(rotationVec.multiply(64.0D));
             EntityHitResult entityHitResult = ProjectileUtil.getEntityCollision(
-                    getServerWorld(),
+                    getWorld(),
                     (ServerPlayerEntity) (Object) this,
                     cameraVec,
                     reachVec,

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/WorldRendererMixin.java
@@ -1,11 +1,13 @@
 package net.hyper_pigeon.eldritch_mobs.mixin.client;
 
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import net.hyper_pigeon.eldritch_mobs.extensions.EntityRenderDispatcherExtensions;
 import net.hyper_pigeon.eldritch_mobs.extensions.GameRendererExtensions;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.entity.EntityRenderDispatcher;
 import net.minecraft.client.util.ObjectAllocator;
 import org.joml.Matrix4f;
+import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -26,7 +28,7 @@ public class WorldRendererMixin {
                     target = "Lnet/minecraft/client/render/entity/EntityRenderDispatcher;configure(Lnet/minecraft/world/World;Lnet/minecraft/client/render/Camera;Lnet/minecraft/entity/Entity;)V"
             )
     )
-    private void configureDispatcher(ObjectAllocator allocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, Matrix4f positionMatrix, Matrix4f projectionMatrix, CallbackInfo ci) {
-        ((EntityRenderDispatcherExtensions) this.entityRenderDispatcher).eldritch_mobs$configureTargetedEldritch(((GameRendererExtensions) gameRenderer).eldritch_mobs$getTargetedEldritch());
+    private void configureDispatcher(ObjectAllocator allocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, Matrix4f positionMatrix, Matrix4f projectionMatrix, GpuBufferSlice fog, Vector4f fogColor, boolean shouldRenderSky, CallbackInfo ci) {
+       ((EntityRenderDispatcherExtensions) this.entityRenderDispatcher).eldritch_mobs$configureTargetedEldritch(((GameRendererExtensions) gameRenderer).eldritch_mobs$getTargetedEldritch());
     }
 }

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/mixin/client/WorldRendererMixin.java
@@ -3,6 +3,7 @@ package net.hyper_pigeon.eldritch_mobs.mixin.client;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import net.hyper_pigeon.eldritch_mobs.extensions.EntityRenderDispatcherExtensions;
 import net.hyper_pigeon.eldritch_mobs.extensions.GameRendererExtensions;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.entity.EntityRenderDispatcher;
 import net.minecraft.client.util.ObjectAllocator;
@@ -21,6 +22,10 @@ public class WorldRendererMixin {
     @Final
     private EntityRenderDispatcher entityRenderDispatcher;
 
+    @Shadow
+    @Final
+    private MinecraftClient client;
+
     @Inject(
             method = "render",
             at = @At(
@@ -29,6 +34,6 @@ public class WorldRendererMixin {
             )
     )
     private void configureDispatcher(ObjectAllocator allocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, Matrix4f positionMatrix, Matrix4f projectionMatrix, GpuBufferSlice fog, Vector4f fogColor, boolean shouldRenderSky, CallbackInfo ci) {
-       ((EntityRenderDispatcherExtensions) this.entityRenderDispatcher).eldritch_mobs$configureTargetedEldritch(((GameRendererExtensions) gameRenderer).eldritch_mobs$getTargetedEldritch());
+        ((EntityRenderDispatcherExtensions) this.entityRenderDispatcher).eldritch_mobs$configureTargetedEldritch(((GameRendererExtensions) this.client.gameRenderer).eldritch_mobs$getTargetedEldritch());
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
   "depends": {
     "fabricloader": ">=0.15.0",
     "fabric": "*",
-    "minecraft": ">=1.21.5",
+    "minecraft": ">=1.21.6",
     "java": ">=17",
     "cloth-config": ">=11.0.0"
   },


### PR DESCRIPTION
## Update to 1.21.6-1.21.8

### Bumped up version numbers
- bumped up to recommended versions of Fabric Loader, Yarn, and Fabric API for 1.21.8 (as listed on https://fabricmc.net/develop/)
- updated version numbers of the dependencies
- Bumped minimum MC version up to 1.21.6

### Update effort due to 1.21.6-1.21.8
- replaced .getEntityWorld() with .getWorld() because name was changed
- replaced "SuggestionProviders.SUMMONABLE_ENTITIES" with a cast() call to fix compiler errors
- updated the read- & writeNbt() methods to the newer system using Read- & Write-Views
- repaired the WorldRenderer, by getting the gameRenderer with an '@ Shadow' because it is no longer in the signature of the render() method
- adapted constructor of ServerPlayerEntityMixin to 1.21.8

## Testing
I tested the new version in minecraft 1.21.8 with:
- cardinal components api 7.0.0-beta.1
- cloth config 19.0.147
- fabric api 0.136.1-1.21.8