### PR TITLE
Updated to 1.21.11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,22 +3,22 @@ org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.10
-yarn_mappings=1.21.10+build.3
-loader_version=0.18.6
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.4
+loader_version=0.19.2
 
 
 
 # Mod Properties
-mod_version = 1.21.0
+mod_version = 1.22.0
 maven_group = net.hyper_pigeon
 archives_base_name = eldritch-mobs
 
 # Dependencies
-fabric_version=0.138.4+1.21.10
-cardinal_version=7.2.0
-modmenu_version=16.0.1
-config_version=20.0.149
-polymer_version=0.14.4+1.21.10
-polymer_blocks_version=0.14.4+1.21.10
+fabric_version=0.141.3+1.21.11
+cardinal_version=7.3.1
+modmenu_version=17.0.0
+config_version=21.11.153
+polymer_version=0.15.2+1.21.11
+polymer_blocks_version=0.15.2+1.21.11
 server_translation_api_version=2.5.2+1.21.9-pre3

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/command/CommandPermissionHelper.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/command/CommandPermissionHelper.java
@@ -1,0 +1,23 @@
+package net.hyper_pigeon.eldritch_mobs.command;
+
+import net.minecraft.command.permission.Permission;
+import net.minecraft.command.permission.PermissionLevel;
+import net.minecraft.server.command.ServerCommandSource;
+
+public class CommandPermissionHelper {
+    protected static boolean hasPermission(ServerCommandSource source, int legacyPermissionLevel){
+        Permission requestedPermission;
+        switch (legacyPermissionLevel){
+            case 0 -> requestedPermission = new Permission.Level(PermissionLevel.ALL);
+            case 1 -> requestedPermission = new Permission.Level(PermissionLevel.MODERATORS);
+            case 2 -> requestedPermission = new Permission.Level(PermissionLevel.GAMEMASTERS);
+            case 3 -> requestedPermission = new Permission.Level(PermissionLevel.ADMINS);
+            case 4 -> requestedPermission = new Permission.Level(PermissionLevel.OWNERS);
+
+            default -> {
+                return false;
+            }
+        }
+        return source.getPermissions().hasPermission(requestedPermission);
+    }
+}

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEldritchCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEldritchCommand.java
@@ -39,7 +39,7 @@ public class SummonEldritchCommand {
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
         dispatcher.register(
-                (LiteralArgumentBuilder)((LiteralArgumentBuilder)CommandManager.literal("summon_eldritch").requires(source -> source.hasPermissionLevel(2)))
+                (LiteralArgumentBuilder)((LiteralArgumentBuilder)CommandManager.literal("summon_eldritch").requires(source -> CommandPermissionHelper.hasPermission(source, 2)))
                         .then(
                                 ((RequiredArgumentBuilder)CommandManager.argument(
                                                 "entity", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEliteCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonEliteCommand.java
@@ -39,7 +39,7 @@ public class SummonEliteCommand {
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
         dispatcher.register(
-                (LiteralArgumentBuilder)((LiteralArgumentBuilder)CommandManager.literal("summon_elite").requires(source -> source.hasPermissionLevel(2)))
+                (LiteralArgumentBuilder)((LiteralArgumentBuilder)CommandManager.literal("summon_elite").requires(source -> CommandPermissionHelper.hasPermission(source, 2)))
                         .then(
                                 ((RequiredArgumentBuilder)CommandManager.argument(
                                                 "entity", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonUltraCommand.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/command/SummonUltraCommand.java
@@ -39,7 +39,7 @@ public class SummonUltraCommand {
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
         dispatcher.register(
-                (LiteralArgumentBuilder)((LiteralArgumentBuilder)CommandManager.literal("summon_ultra").requires(source -> source.hasPermissionLevel(2)))
+                (LiteralArgumentBuilder)((LiteralArgumentBuilder)CommandManager.literal("summon_ultra").requires(source -> CommandPermissionHelper.hasPermission(source, 2)))
                         .then(
                                 ((RequiredArgumentBuilder)CommandManager.argument(
                                                 "entity", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)

--- a/src/main/java/net/hyper_pigeon/eldritch_mobs/config/EldritchMobsModMenuIntegration.java
+++ b/src/main/java/net/hyper_pigeon/eldritch_mobs/config/EldritchMobsModMenuIntegration.java
@@ -3,11 +3,12 @@ package net.hyper_pigeon.eldritch_mobs.config;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfigClient;
 
 public class EldritchMobsModMenuIntegration implements ModMenuApi {
 
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        return screen -> AutoConfig.getConfigScreen(EldritchMobsConfig.class, screen).get();
+        return screen -> AutoConfigClient.getConfigScreen(EldritchMobsConfig.class, screen).get();
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
   "depends": {
     "fabricloader": ">=0.15.0",
     "fabric": "*",
-    "minecraft": ">=1.21.9",
+    "minecraft": "=1.21.11",
     "java": ">=17",
     "cloth-config": ">=11.0.0"
   },


### PR DESCRIPTION
## Update to 1.21.11

### Bumped up version numbers
- bumped up to recommended versions of Fabric Loader, Yarn, and Fabric API for 1.21.11 (as listed on https://fabricmc.net/develop/)
- updated version numbers of the dependencies
- Bumped required MC version up to 1.21.11
- Incremented the version number of eldritch-mobs to 1.22.0

### Update effort due to 1.21.11 
- `source.hasPermissionLevel()` no longer exists and was replaced with a method call of a new helper class

### New class: `CommandPermissionHelper`
- was addded because the command permission system got reworked
- added the `hasPermission()` method to replace permission checks in a legacy friendly way

### Update effort due to Cloth Config 21.11.153
- `AutoConfig.getConfigScreen()` is now marked for removal and was therefore replaced with `AutoConfigClient.getConfigScreen()`

## Testing
I tested the new version in minecraft 1.21.11 with:
- cardinal components api 7.3.1
- cloth config 21.11.153
- fabric api 0.141.3-1.21.11
